### PR TITLE
Add some hover effects + Misc fixes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -80,10 +80,13 @@
         <div class="flex md:order-2 justify-center items-center">
           <button type="button" class="text-center mr-3 md:mr-0 md:pt-4">
             <div id="dark-classic-btn" class="md:inline-block relative">
-              <div class="font-semibold inline-flex items-center">
+              <div
+                class="font-semibold inline-flex items-center px-3 py-2 hover:bg-purple border border-purple rounded text-purple hover:text-white"
+              >
                 <span class="mr-1 text-xs md:text-base">Darklang classic</span>
                 <svg
-                  class="fill-current h-4 w-4"
+                  id="arrowIcon"
+                  class="fill-current h-4 w-4 transform transition duration-200 ease-in-out"
                   xmlns="http://www.w3.org/2000/svg"
                   viewBox="0 0 20 20"
                 >
@@ -94,7 +97,7 @@
               </div>
               <div
                 id="dark-classic-menu"
-                class="absolute hidden w-full bg-[#3F3F3F] text-white pt-1 rounded-b-lg"
+                class="absolute hidden w-full bg-dark-gray text-white pt-1 rounded-b-lg"
               >
                 <ul>
                   <li>
@@ -144,9 +147,9 @@
         >
           <ul class="flex flex-col md:flex-row md:space-x-8 p-6 md:p-0 mt-4">
             <!-- <li>
-                        Disabled for now as it points to old docs
-                        <a href="https://docs.darklang.com" target=”_blank” class="text-white">Documentation</a>
-                    </li> -->
+              Disabled for now as it points to old docs
+              <a href="https://docs.darklang.com" target=”_blank” class="text-white">Documentation</a>
+          </li> -->
             <li class="hover:text-blue border-b md:border-none">
               <a
                 href="https://blog.darklang.com"
@@ -227,7 +230,7 @@
           ></span>
           <button
             type="submit"
-            class="bg-blue text-white rounded px-4 py-3 mt-6 md:mt-0"
+            class="bg-blue hover:bg-purple text-white rounded px-4 py-3 mt-6 md:mt-0"
           >
             Send me project updates
           </button>
@@ -272,7 +275,7 @@
 
     <!-- At a glance section -->
     <section
-      class="mx-auto my-28 p-4 md:p-0 md:max-w-4xl md:my-52 font-Quicksand mt-40 2xl:mt-72"
+      class="mx-auto my-28 p-4 md:p-0 md:max-w-4xl md:my-52 font-Quicksand mt-52 2xl:mt-96"
     >
       <div class="text-base leading-6 mx-8">
         <ul>
@@ -296,14 +299,12 @@
             <ul class="text-lg font-normal m-4">
               <li class="flex flex-row ml-4">
                 <p class="text-purple text-2xl mr-3 leading-6 font-bold">-</p>
-                <span class="text-dark-charcoal">
-                  Static, immutable, records and enums</span
-                >
+                <span> Static, immutable, records and enums</span>
               </li>
 
               <li class="flex flex-row ml-4">
                 <p class="text-purple text-2xl mr-3 leading-6 font-bold">-</p>
-                <span class="text-dark-charcoal">
+                <span class="text-dark-gray">
                   <code
                     class="font-FiraCode text-xs flex-wrap md:text-sm inline-flex text-left items-center space-x-4 bg-code-background text-blue rounded py-1 px-2"
                     >Option</code
@@ -319,12 +320,12 @@
 
               <li class="flex flex-row ml-4">
                 <p class="text-purple text-2xl mr-3 leading-6 font-bold">-</p>
-                <span class="text-dark-charcoal">Garbage Collected</span>
+                <span class="text-dark-gray">Garbage Collected</span>
               </li>
 
               <li class="flex flex-row ml-4">
                 <p class="text-purple text-2xl mr-3 leading-6 font-bold">-</p>
-                <span class="text-dark-charcoal">
+                <span class="text-dark-gray">
                   Fully async runtime without
                   <code
                     class="font-FiraCode text-xs flex-wrap md:text-sm inline-flex text-left items-center space-x-4 bg-code-background text-blue rounded py-1 px-2"
@@ -341,7 +342,7 @@
 
               <li class="flex flex-row ml-4">
                 <p class="text-purple text-2xl mr-3 leading-6 font-bold">-</p>
-                <span class="text-dark-charcoal">Unicode first</span>
+                <span class="text-dark-gray">Unicode first</span>
               </li>
               <!--
               <li class="text-purple flex flex-row ml-4">
@@ -351,7 +352,7 @@
                     class="bg-[#E3D3FF] text-purple px-1.5 py-0.5 rounded text-sm"
                     >2024</span
                   >
-                  <span class="text-dark-charcoal">
+                  <span class="text-dark-gray">
                     Full type checking: after prototyping, run the static
                     typechecker to catch errors - and get confidence your
                     program works
@@ -380,10 +381,10 @@
             <ul class="text-lg font-normal m-4">
               <li class="flex flex-row mt-1">
                 <p class="text-purple text-2xl mr-3 leading-6 font-bold">-</p>
-                <span class="text-dark-charcoal">
+                <span class="text-dark-gray">
                   Instantly run any package from the CLI:
                   <code
-                    class="font-FiraCode text-xs flex-wrap md:text-sm inline-flex text-left items-center space-x-4 bg-code-background text-dark-charcoal rounded py-1 px-2"
+                    class="font-FiraCode text-xs flex-wrap md:text-sm inline-flex text-left items-center space-x-4 bg-code-background text-dark-gray rounded py-1 px-2"
                     ><span class="text-blue pr-2">darklang </span
                     >@username.functionName <span class="text-blue">arg1</span>
                     <span class="text-purple">arg2</span></code
@@ -393,7 +394,7 @@
 
               <li class="flex flex-row mt-1">
                 <p class="text-purple text-2xl mr-3 leading-6 font-bold">-</p>
-                <span class="text-dark-charcoal">
+                <span class="text-dark-gray">
                   Streaming package manager with no
                   <code
                     class="font-FiraCode text-xs flex-wrap md:text-sm inline-flex text-left items-center bg-code-background rounded py-1 px-2 text-blue"
@@ -405,7 +406,7 @@
 
               <li class="text-purple flex flex-row mt-1">
                 <span class="text-2xl mr-3 leading-6 font-bold"> - </span>
-                <span class="text-dark-charcoal">
+                <span class="text-dark-gray">
                   Single binary to install - no environments or containers to
                   setup
                 </span>
@@ -413,7 +414,7 @@
 
               <li class="text-purple flex flex-row mt-1">
                 <p class="text-purple text-2xl mr-3 leading-6 font-bold">-</p>
-                <span class="text-dark-charcoal">
+                <span class="text-dark-gray">
                   <!-- this might be a good spot to say that we intend to add streaming compilation in the future -->
                   Interpreted with no compile step
                 </span>
@@ -440,27 +441,27 @@
             <ul class="text-lg font-normal m-4">
               <li class="flex flex-row mt-1">
                 <p class="text-purple text-2xl mr-3 leading-6 font-bold">-</p>
-                <span class="text-dark-charcoal">
+                <span class="text-dark-gray">
                   Works with VS Code (or any LSP-editor) and GitHub Copilot
                 </span>
               </li>
 
               <li class="flex flex-row mt-1 pt-4">
                 <p class="text-purple text-2xl mr-3 leading-6 font-bold">-</p>
-                <span class="text-dark-charcoal">Gradual Static Typing</span>
+                <span class="text-dark-gray">Gradual Static Typing</span>
               </li>
 
               <ul class="font-normal mx-4">
                 <li class="text-purple flex flex-row mt-1">
                   <p class="text-purple text-2xl mr-3 leading-6 font-bold">-</p>
-                  <span class="text-dark-charcoal">
+                  <span class="text-dark-gray">
                     When prototyping, don't let the type checker hold you up -
                     just run your program until you hit an error
                   </span>
                 </li>
                 <li class="text-purple flex flex-row mt-1">
                   <p class="text-purple text-2xl mr-3 leading-6 font-bold">-</p>
-                  <span class="text-dark-charcoal">
+                  <span class="text-dark-gray">
                     <span
                       class="bg-[#E3D3FF] text-purple px-1.5 py-0.5 rounded text-sm"
                       >2024</span
@@ -473,7 +474,7 @@
 
               <li class="flex flex-row mt-1 pt-4">
                 <p class="text-purple text-2xl mr-3 leading-6 font-bold">-</p>
-                <span class="text-dark-charcoal">
+                <span class="text-dark-gray">
                   <span
                     class="bg-[#E3D3FF] text-purple px-1.5 py-0.5 rounded text-sm"
                     >Optional</span
@@ -491,7 +492,7 @@
 
               <li class="flex flex-row mt-1 pt-4">
                 <p class="text-purple text-2xl mr-3 leading-6 font-bold">-</p>
-                <span class="text-dark-charcoal">
+                <span class="text-dark-gray">
                   Package items (functions, types and constants) are versioned
                   and immutable, taking the worry out of taking on dependencies
                 </span>
@@ -500,14 +501,14 @@
               <ul class="font-normal mx-4">
                 <li class="text-purple flex flex-row mt-1">
                   <span class="text-lg mx-3 font-bold"> - </span>
-                  <span class="text-dark-charcoal">
+                  <span class="text-dark-gray">
                     Only download the specific package items you use
                   </span>
                 </li>
 
                 <li class="text-purple flex flex-row mt-1">
                   <span class="text-lg mx-3 font-bold"> - </span>
-                  <span class="text-dark-charcoal">
+                  <span class="text-dark-gray">
                     Only upgrade the specific package items you use
                   </span>
                 </li>
@@ -518,7 +519,7 @@
                       class="bg-[#E3D3FF] text-purple px-1.5 py-0.5 rounded text-sm"
                       >2024</span
                     >
-                    <span class="text-dark-charcoal">
+                    <span class="text-dark-gray">
                       Automated dependency upgrades, as we track deprecation
                       status, and know what functions are pure and safe to
                       update.
@@ -528,7 +529,7 @@
 
                 <li class="text-purple flex flex-row mt-1">
                   <span class="text-lg mx-3 font-bold"> - </span>
-                  <span class="text-dark-charcoal">
+                  <span class="text-dark-gray">
                     Different packages can rely on different versions of other
                     packages
                   </span>
@@ -536,7 +537,7 @@
 
                 <li class="text-purple flex flex-row mt-1">
                   <span class="text-lg mx-3 font-bold"> - </span>
-                  <span class="text-dark-charcoal">
+                  <span class="text-dark-gray">
                     Use multiple versions of the same package item at once:
                     allows testing new versions without having to change an
                     entire package version, lowering risk.
@@ -550,7 +551,7 @@
                       class="bg-[#E3D3FF] text-purple px-1.5 py-0.5 rounded text-sm"
                       >2024</span
                     >
-                    <span class="text-dark-charcoal">
+                    <span class="text-dark-gray">
                       Share pre-release functions trivially, without
                       contributors needing to check out your git repo or set up
                       anything
@@ -561,7 +562,7 @@
 
               <li class="flex flex-row mt-1 pt-4">
                 <p class="text-purple text-2xl mr-3 leading-6 font-bold">-</p>
-                <span class="text-dark-charcoal">
+                <span class="text-dark-gray">
                   <span
                     class="bg-[#E3D3FF] text-purple px-1.5 py-0.5 rounded text-sm"
                     >2024</span
@@ -593,14 +594,12 @@
             <ul class="text-lg font-normal m-4">
               <li class="text-purple flex flex-row mt-1">
                 <span class="text-2xl mr-3 leading-6 font-bold"> - </span>
-                <span class="text-dark-charcoal">
-                  Works with GitHub Copilot
-                </span>
+                <span class="text-dark-gray"> Works with GitHub Copilot </span>
               </li>
 
               <li class="text-purple flex flex-row mt-1">
                 <span class="text-2xl mr-3 leading-6 font-bold"> - </span>
-                <span class="text-dark-charcoal">
+                <span class="text-dark-gray">
                   We redesigned the dark language and tooling to enable
                   GenAI-generated programs, including exposing language tools to
                   GenAI tools, allowing running partial and incomplete programs
@@ -615,7 +614,7 @@
                     class="bg-[#E3D3FF] text-purple px-1.5 py-0.5 rounded text-sm"
                     >2024</span
                   >
-                  <span class="text-dark-charcoal"
+                  <span class="text-dark-gray"
                     >Build short CLI programs from prompts
                     <code
                       class="font-FiraCode text-sm block md:inline-flex text-left items-center bg-code-background text-gray-600 rounded py-1 px-2 mt-1"
@@ -630,7 +629,7 @@
 
               <li class="text-purple flex flex-row mt-1">
                 <span class="text-2xl mr-3 leading-6 font-bold"> - </span>
-                <span class="text-dark-charcoal">
+                <span class="text-dark-gray">
                   <span
                     class="bg-[#E3D3FF] text-purple px-1.5 py-0.5 rounded text-sm"
                     >2024</span
@@ -641,7 +640,7 @@
 
               <li class="text-purple flex flex-row mt-1">
                 <span class="text-2xl mr-3 leading-6 font-bold"> - </span>
-                <span class="text-dark-charcoal">
+                <span class="text-dark-gray">
                   <span
                     class="bg-[#E3D3FF] text-purple px-1.5 py-0.5 rounded text-sm"
                     >2024</span
@@ -834,11 +833,13 @@
       // Menu button
       const button = document.querySelector("#menu-button");
       const menu = document.querySelector("#menu");
+      const arrow = document.getElementById("arrowIcon");
       const darkClassicBtn = document.querySelector("#dark-classic-btn");
       const darkClassicMenu = document.querySelector("#dark-classic-menu");
 
       darkClassicBtn.addEventListener("click", () => {
         darkClassicMenu.classList.toggle("hidden");
+        arrow.classList.toggle("rotate-180");
       });
 
       button.addEventListener("click", () => {

--- a/public/index.html
+++ b/public/index.html
@@ -81,7 +81,7 @@
           <button type="button" class="text-center mr-3 md:mr-0 md:pt-4">
             <div id="dark-classic-btn" class="md:inline-block relative">
               <div
-                class="font-semibold inline-flex items-center px-3 py-2 hover:bg-purple border border-purple rounded text-purple hover:text-white"
+                class="font-semibold inline-flex items-center px-3 py-2 hover:text-purple"
               >
                 <span class="mr-1 text-xs md:text-base">Darklang classic</span>
                 <svg

--- a/public/signup.html
+++ b/public/signup.html
@@ -18,7 +18,7 @@
 
   <body class="bg-light-background box-border mx-auto w-full font-Quicksand">
     <!--Navbar-->
-    <nav class="sticky bg-light-background w-full top-0 left-0">
+    <nav class="sticky bg-light-background w-full top-0 left-0 z-50">
       <div
         class="container flex flex-wrap items-center justify-between mx-auto p-4"
       >
@@ -31,15 +31,15 @@
         </a>
 
         <div class="flex md:order-2 justify-center items-center">
-          <button type="button" class="text-center mr-3 md:mr-0 pt-4">
-            <div
-              id="dark-classic-btn"
-              class="group md:inline-block relative hidden"
-            >
-              <div class="text-pink font-semibold inline-flex items-center">
+          <button type="button" class="text-center mr-3 md:mr-0 md:pt-4">
+            <div id="dark-classic-btn" class="md:inline-block relative">
+              <div
+                class="font-semibold inline-flex items-center px-3 py-2 hover:bg-purple border border-purple rounded text-purple hover:text-white"
+              >
                 <span class="mr-1 text-xs md:text-base">Darklang classic</span>
                 <svg
-                  class="fill-current h-4 w-4"
+                  id="arrowIcon"
+                  class="fill-current h-4 w-4 transform transition duration-200 ease-in-out"
                   xmlns="http://www.w3.org/2000/svg"
                   viewBox="0 0 20 20"
                 >
@@ -49,19 +49,20 @@
                 </svg>
               </div>
               <div
-                class="absolute hidden w-full text-white bg-gradient-to-b from-gray-900 to-gray-800 pt-1 group-hover:block rounded-b-lg"
+                id="dark-classic-menu"
+                class="absolute hidden w-full bg-dark-gray text-white pt-1 rounded-b-lg"
               >
                 <ul>
                   <li>
                     <a
-                      class="hover:bg-indigo-400 py-2 px-4 block"
+                      class="hover:bg-blue py-2 px-4 block"
                       href="https://login.darklang.com"
                       >Log in</a
                     >
                   </li>
                   <li>
                     <a
-                      class="hover:bg-indigo-400 py-2 px-4 block"
+                      class="hover:bg-blue py-2 px-4 block rounded-b-lg"
                       href="./signup"
                       >Sign up</a
                     >
@@ -95,14 +96,14 @@
 
         <div
           id="menu"
-          class="md:order-1 hidden md:flex bg-white md:bg-transparent justify-between items-center w-full md:w-auto"
+          class="rounded-b-lg bg-md:order-1 hidden md:flex bg-white/70 md:bg-transparent justify-between items-center w-full md:w-auto"
         >
-          <ul class="flex flex-col md:flex-row md:space-x-8 p-4 md:p-0 mt-4">
+          <ul class="flex flex-col md:flex-row md:space-x-8 p-6 md:p-0 mt-4">
             <!-- <li>
-                  Disabled for now as it points to old docs
-                  <a href="https://docs.darklang.com" target=”_blank” class="text-white">Documentation</a>
-              </li> -->
-            <li>
+                Disabled for now as it points to old docs
+                <a href="https://docs.darklang.com" target=”_blank” class="text-white">Documentation</a>
+            </li> -->
+            <li class="hover:text-blue border-b md:border-none">
               <a
                 href="https://blog.darklang.com"
                 target="”_blank”"
@@ -110,7 +111,7 @@
                 >Blog</a
               >
             </li>
-            <li>
+            <li class="hover:text-blue border-b md:border-none">
               <a
                 href="https://darklang.com/discord"
                 target="”_blank”"
@@ -118,7 +119,7 @@
                 >Discord</a
               >
             </li>
-            <li>
+            <li class="hover:text-blue border-b md:border-none">
               <a
                 href="https://github.com/darklang/dark"
                 target="”_blank”"
@@ -126,7 +127,7 @@
                 >Github</a
               >
             </li>
-            <li>
+            <li class="hover:text-blue">
               <a
                 href="https://darklang.com/sponsor"
                 target="”_blank”"
@@ -265,7 +266,7 @@
             >
           </div>
           <button
-            class="bg-purple text-white px-5 py-2 rounded mb-3 mt-4 hover:bg-pink"
+            class="bg-purple text-white px-5 py-2 rounded mb-3 mt-4 hover:bg-pink cursor-pointer hover:bg-blue"
           >
             Create account
           </button>
@@ -431,11 +432,17 @@
     <script>
       const button = document.querySelector("#menu-button");
       const menu = document.querySelector("#menu");
+      const arrow = document.getElementById("arrowIcon");
       const darkClassicBtn = document.querySelector("#dark-classic-btn");
+      const darkClassicMenu = document.querySelector("#dark-classic-menu");
+
+      darkClassicBtn.addEventListener("click", () => {
+        darkClassicMenu.classList.toggle("hidden");
+        arrow.classList.toggle("rotate-180");
+      });
 
       button.addEventListener("click", () => {
         menu.classList.toggle("hidden");
-        darkClassicBtn.classList.toggle("hidden");
       });
     </script>
   </body>

--- a/public/signup.html
+++ b/public/signup.html
@@ -34,7 +34,7 @@
           <button type="button" class="text-center mr-3 md:mr-0 md:pt-4">
             <div id="dark-classic-btn" class="md:inline-block relative">
               <div
-                class="font-semibold inline-flex items-center px-3 py-2 hover:bg-purple border border-purple rounded text-purple hover:text-white"
+                class="font-semibold inline-flex items-center px-3 py-2 hover:text-purple"
               >
                 <span class="mr-1 text-xs md:text-base">Darklang classic</span>
                 <svg

--- a/public/style.css
+++ b/public/style.css
@@ -603,6 +603,10 @@ video {
   top: 0.75rem;
 }
 
+.z-50{
+  z-index: 50;
+}
+
 .m-0{
   margin: 0px;
 }
@@ -724,8 +728,8 @@ video {
   margin-top: 1rem;
 }
 
-.mt-40{
-  margin-top: 10rem;
+.mt-52{
+  margin-top: 13rem;
 }
 
 .mt-6{
@@ -823,6 +827,11 @@ video {
 
 .-translate-y-6{
   --tw-translate-y: -1.5rem;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+.rotate-180{
+  --tw-rotate: 180deg;
   transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
 }
 
@@ -927,6 +936,11 @@ video {
   border-color: rgb(156 163 175 / var(--tw-border-opacity));
 }
 
+.border-purple{
+  --tw-border-opacity: 1;
+  border-color: rgb(149 91 159 / var(--tw-border-opacity));
+}
+
 .border-r-white\/30{
   border-right-color: rgb(255 255 255 / 0.3);
 }
@@ -949,6 +963,11 @@ video {
 .bg-code-background{
   --tw-bg-opacity: 1;
   background-color: rgb(245 244 241 / var(--tw-bg-opacity));
+}
+
+.bg-dark-gray{
+  --tw-bg-opacity: 1;
+  background-color: rgb(47 47 47 / var(--tw-bg-opacity));
 }
 
 .bg-light-background{
@@ -1065,6 +1084,11 @@ video {
 .px-20{
   padding-left: 5rem;
   padding-right: 5rem;
+}
+
+.px-3{
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
 }
 
 .px-4{
@@ -1253,9 +1277,9 @@ video {
   color: rgb(116 122 185 / var(--tw-text-opacity));
 }
 
-.text-dark-charcoal{
+.text-dark-gray{
   --tw-text-opacity: 1;
-  color: rgb(51 51 51 / var(--tw-text-opacity));
+  color: rgb(47 47 47 / var(--tw-text-opacity));
 }
 
 .text-gray-300{
@@ -1390,6 +1414,11 @@ video {
   border-width: 1px;
 }
 
+.hover\:border-purple:hover{
+  --tw-border-opacity: 1;
+  border-color: rgb(149 91 159 / var(--tw-border-opacity));
+}
+
 .hover\:bg-blue:hover{
   --tw-bg-opacity: 1;
   background-color: rgb(116 122 185 / var(--tw-bg-opacity));
@@ -1400,6 +1429,16 @@ video {
   background-color: rgb(129 140 248 / var(--tw-bg-opacity));
 }
 
+.hover\:bg-light-background:hover{
+  --tw-bg-opacity: 1;
+  background-color: rgb(250 250 250 / var(--tw-bg-opacity));
+}
+
+.hover\:bg-purple:hover{
+  --tw-bg-opacity: 1;
+  background-color: rgb(149 91 159 / var(--tw-bg-opacity));
+}
+
 .hover\:text-blue:hover{
   --tw-text-opacity: 1;
   color: rgb(116 122 185 / var(--tw-text-opacity));
@@ -1408,6 +1447,11 @@ video {
 .hover\:text-purple:hover{
   --tw-text-opacity: 1;
   color: rgb(149 91 159 / var(--tw-text-opacity));
+}
+
+.hover\:text-white:hover{
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity));
 }
 
 .focus\:border-purple:focus{
@@ -1675,6 +1719,10 @@ video {
 
   .\32xl\:mt-72{
     margin-top: 18rem;
+  }
+
+  .\32xl\:mt-96{
+    margin-top: 24rem;
   }
 
   .\32xl\:max-w-3xl{

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -21,7 +21,7 @@ module.exports = {
         "light-background": "#FAFAFA",
         purple: "#955B9F",
         blue: "#747AB9",
-        "dark-charcoal": "#333333",
+        "dark-gray": "#2F2F2F",
         "code-background": "#F5F4F1",
       },
       flex: {


### PR DESCRIPTION
This PR includes the following changes: 
- Add hover effects to buttons.
- Fix margins for wide and mobile screens.
- Fix signup page navbar issue.
- Replace #333333 with #2F2F2F from our original palette

**Navbar issue**
![Frame 2 (2)](https://github.com/darklang/darklang.com/assets/87861924/a871d04e-b91b-4318-8b70-a3180383771d)


**Arrow toggle**
![Screenshot 2023-10-23 at 14 49 27](https://github.com/darklang/darklang.com/assets/87861924/ae69cf83-d061-4f8e-807b-197bc69aa5a3)

![Screenshot 2023-10-23 at 14 49 03](https://github.com/darklang/darklang.com/assets/87861924/d636cb7e-0f08-4e7e-b9ed-34e6b5d7a922)




The following screenshots were just tests and are not included in the PR
<img width="1504" alt="Screenshot 2023-10-23 at 14 24 48" src="https://github.com/darklang/darklang.com/assets/87861924/082b6ef1-4581-4bc6-8cdf-76bd387736af">
<img width="1478" alt="Screenshot 2023-10-23 at 14 47 46" src="https://github.com/darklang/darklang.com/assets/87861924/04e36886-0872-4727-b341-bf4661e5d653">
